### PR TITLE
lib: verbose output during installation

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -57,6 +57,7 @@ async function listTags(git) {
 }
 
 async function cloneRepo(tag, git, dst) {
+  console.log(`Cloning: ${git} ${tag}`);
   let result = null;
 
   // Clone the remote repository with matching tag.

--- a/lib/gpm.js
+++ b/lib/gpm.js
@@ -23,7 +23,7 @@ const path = require('path');
 const semver = require('../vendor/semver');
 const readFile = util.promisify(fs.readFile);
 const access = util.promisify(fs.access);
-const {execFile} = child_process;
+const {execFile, spawn} = child_process;
 const {cloneRepo, verifyRepo, listTags} = require('./git');
 
 const NODE_GYP = path.resolve(__dirname, '../vendor/node-gyp/bin/node-gyp.js');
@@ -118,16 +118,30 @@ async function locatePkg(dst, walk = true) {
 }
 
 async function rebuild(dst) {
+  console.log(`Building: ${dst}`);
   return new Promise((resolve, reject) => {
-    execFile(NODE_GYP, ['rebuild'], {cwd: dst}, (err, stdout) => {
-      if (err)
-        reject(err);
-      resolve(stdout);
+    const proc = spawn(NODE_GYP, ['rebuild'], {cwd: dst});
+
+    proc.stdout.on('data', (data) => {
+      console.log(data.toString('utf-8'));
+    });
+
+    proc.on('close', (code) => {
+      resolve(code);
+    });
+
+    proc.on('exit', (code) => {
+      resolve(code);
+    });
+
+    proc.on('error', (err) => {
+      reject(err);
     });
   });
 }
 
 async function install(dst, prefix = null, options = {}) {
+  console.log(`Installing: ${dst}`);
   const {root, pkg} = await locatePkg(dst, false);
 
   if (prefix == null)


### PR DESCRIPTION
Replaces `execFile` with `spawn` to enable output logging.
Adds console logging for main functions.

Overall provides some progress to watch.

Example:

```
--> gpm install
Installing: /Users/matthewzipkin/Desktop/work/gpm-bcoin/bcoin
Cloning: https://github.com/bcoin-org/bcfg.git v0.1.6
Cloning: https://github.com/bcoin-org/bcrypto.git v3.1.11
Cloning: https://github.com/bcoin-org/bcurl.git v0.1.6
Cloning: https://github.com/bcoin-org/bdb.git v1.1.7
Cloning: https://github.com/bcoin-org/bdns.git v0.1.5
Cloning: https://github.com/bcoin-org/bevent.git v0.1.5
Cloning: https://github.com/bcoin-org/bfile.git v0.2.1
Cloning: https://github.com/bcoin-org/bfilter.git v1.0.5
Cloning: https://github.com/bcoin-org/bheep.git v0.1.5
Cloning: https://github.com/bcoin-org/binet.git v0.3.5
Cloning: https://github.com/bcoin-org/blgr.git v0.1.7
Cloning: https://github.com/bcoin-org/blru.git v0.1.6
Cloning: https://github.com/bcoin-org/blst.git v0.1.5
Cloning: https://github.com/bcoin-org/bmutex.git v0.1.6
Cloning: https://github.com/bcoin-org/brq.git v0.1.8
Cloning: https://github.com/bcoin-org/bs32.git v0.1.6
Cloning: https://github.com/chjj/bsert.git v0.0.10
Cloning: https://github.com/bcoin-org/bsip.git v0.1.9
Cloning: https://github.com/bcoin-org/bsock.git v0.1.9
Cloning: https://github.com/bcoin-org/bsocks.git v0.2.5
Cloning: https://github.com/bcoin-org/bstring.git v0.3.9
Cloning: https://github.com/bcoin-org/btcp.git v0.1.5
Cloning: https://github.com/chjj/buffer-map.git v0.0.7
Cloning: https://github.com/bcoin-org/bufio.git v1.0.6
Cloning: https://github.com/bcoin-org/bupnp.git v0.2.6
Cloning: https://github.com/bcoin-org/bval.git v0.1.6
Cloning: https://github.com/bcoin-org/bweb.git v0.1.9
Cloning: https://github.com/chjj/loady.git v0.0.1
Cloning: https://github.com/bcoin-org/mrmr.git v0.1.8
Cloning: https://github.com/chjj/n64.git v0.2.10
Cloning: https://github.com/braydonf/nan.git v2.13.2
Cloning: https://github.com/bcoin-org/bmocha.git v2.1.3
Installing: /Users/matthewzipkin/Desktop/work/gpm-bcoin/bcoin/node_modules/bcfg
Installing: /Users/matthewzipkin/Desktop/work/gpm-bcoin/bcoin/node_modules/bcrypto
Building: /Users/matthewzipkin/Desktop/work/gpm-bcoin/bcoin/node_modules/bcrypto
  CC(target) Release/obj.target/bcrypto/src/aead/aead.o

  CC(target) Release/obj.target/bcrypto/src/aes/aes.o

  CC(target) Release/obj.target/bcrypto/src/blake2b/blake2b.o

  CC(target) Release/obj.target/bcrypto/src/blake2s/blake2s.o

  CC(target) Release/obj.target/bcrypto/src/chacha20/chacha20.o

  CC(target) Release/obj.target/bcrypto/src/dsa/dsa.o

...
```
