### PR TITLE
lib: join global node_modules lib

### DIFF
--- a/lib/package.js
+++ b/lib/package.js
@@ -393,7 +393,7 @@ class Package {
     let dirs = [];
 
     if (options.global)
-      dirs.push(path.join(this.env.global), './lib');
+      dirs.push(path.join(this.env.global, './lib'));
     else
       dirs = this.getParents('dir', true);
 


### PR DESCRIPTION
Testing global install I found that `bin/bcoin` would be a broken symlink because of missing `../lib/node_modules`. I found that the global `node_modules` was being created without `lib` prefix. I believe this fix is appropriate for the issue.