### PR TITLE
all: lint

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -63,7 +63,7 @@ async function ensureSymlink(target, dst) {
   if (existing && existing !== target)
     throw new Error(`Existing linked installation at '${dst}'.`);
   else if (existing)
-    return;
+    return null;
 
   return symlink(target, dst);
 }
@@ -130,4 +130,4 @@ module.exports = {
   ensureSymlink,
   exists,
   unlinkRecursive
-}
+};

--- a/lib/environment.js
+++ b/lib/environment.js
@@ -24,8 +24,8 @@ const mkdir = util.promisify(fs.mkdir);
 const access = util.promisify(fs.access);
 const writeFile = util.promisify(fs.writeFile);
 const unlink = util.promisify(fs.unlink);
-const child_process = require('child_process');
-const {spawn} = child_process;
+const cp = require('child_process');
+const {spawn} = cp;
 
 /**
  * Environment
@@ -168,8 +168,8 @@ class Environment {
     if (!isWin32())
       return;
 
-    let body = `:: File created by gpk.\r\n`;
-    body += `@ECHO OFF\r\n`;
+    let body = ':: File created by gpk.\r\n';
+    body += '@ECHO OFF\r\n';
     body += `node "${target}" %*\r\n`;
 
     await writeFile(`${target}.cmd`, body);
@@ -177,7 +177,7 @@ class Environment {
 
   async unlinkCmd(target) {
     if (!isWin32())
-      return;
+      return null;
 
     return unlink(`${target}.cmd`);
   }

--- a/lib/git.js
+++ b/lib/git.js
@@ -19,15 +19,15 @@
 const util = require('util');
 const fs = require('fs');
 const path = require('path');
-const child_process = require('child_process');
-const exec = util.promisify(child_process.exec);
-const {execFile, spawn} = child_process;
+const cp = require('child_process');
+const exec = util.promisify(cp.exec);
+const {execFile, spawn} = cp;
 const crypto = require('crypto');
 const semver = require('../vendor/semver');
 
 async function listTags(git) {
   const cmd = `git ls-remote --tags ${git}`;
-  const {stdout, stderr} = await exec(cmd);
+  const {stdout} = await exec(cmd);
 
   // Split and trim the last line.
   const items = stdout.trim().split('\n');
@@ -62,7 +62,7 @@ async function listTags(git) {
 
 async function listBranches(git) {
   const cmd = `git ls-remote --heads ${git}`;
-  const {stdout, stderr} = await exec(cmd);
+  const {stdout} = await exec(cmd);
 
   const items = stdout.trim().split('\n');
 
@@ -89,7 +89,7 @@ function sortTags(tags, desc) {
 
   // Sort lexicographically with the largest value at the beginning.
   const sorted = filtered.sort((a, b) => {
-    if (a == b)
+    if (a === b)
       return 0;
     else
       return cmp(a, b) ? 1 : -1;
@@ -121,23 +121,22 @@ async function cloneRepo(tag, git, dst) {
 }
 
 async function getHeadCommit(git) {
-  const cmd = `git rev-parse HEAD`;
+  const cmd = 'git rev-parse HEAD';
 
-  const {stdout, stderr} = await exec(cmd, {cwd: git});
+  const {stdout} = await exec(cmd, {cwd: git});
 
   return stdout.trim();
 }
 
 async function verifyRepo(tag, commit, dst, stdio) {
-  let result = Object.create(null);
   let args = ['verify-tag', tag];
   if (!tag)
-    args = ['verify-commit', commit]
+    args = ['verify-commit', commit];
 
   return new Promise((resolve, reject) => {
     const child = spawn('git', args, {cwd: dst, stdio: stdio});
     child.once('error', err => reject(err));
-    child.once('close', code => {
+    child.once('close', (code) => {
       if (code === 0) {
         resolve();
       } else {
@@ -202,9 +201,8 @@ async function treeHash(dst, base, algo) {
 
 async function cloneFiles(git, dst) {
   const cmd = `git clone --depth=1 ${git} ${dst}`;
-  const {stdout, stderr} = await exec(cmd);
+  await exec(cmd);
 }
-
 
 module.exports = {
   sortTags,
@@ -218,4 +216,4 @@ module.exports = {
   treeHash,
   checksum,
   cloneFiles
-}
+};

--- a/lib/package.js
+++ b/lib/package.js
@@ -18,7 +18,7 @@
 
 const util = require('util');
 const fs = require('fs');
-const child_process = require('child_process');
+const cp = require('child_process');
 const path = require('path');
 const semver = require('../vendor/semver');
 const readFile = util.promisify(fs.readFile);
@@ -29,7 +29,7 @@ const unlink = util.promisify(fs.unlink);
 const readdir = util.promisify(fs.readdir);
 const rename = util.promisify(fs.rename);
 const mkdir = util.promisify(fs.mkdir);
-const {spawn} = child_process;
+const {spawn} = cp;
 const nodeGyp = path.resolve(__dirname, '../vendor/node-gyp/bin/node-gyp.js');
 const glob = util.promisify(require('../vendor/glob'));
 
@@ -62,7 +62,6 @@ const {
  */
 
 class Package {
-
   /**
    * Initialize the package.
    * @param {String} dir
@@ -155,7 +154,7 @@ class Package {
     if (info.scripts == null) {
       info.scripts = {
         test: 'echo \"Error: no test specified\" && exit 1'
-      }
+      };
     }
 
     return info;
@@ -209,14 +208,14 @@ class Package {
         if (dirparent === cwd || !walk)
           break;
         else
-          cwd = dirparent
+          cwd = dirparent;
       }
     }
 
     let info = null;
 
     if (data) {
-      info = JSON.parse(data)
+      info = JSON.parse(data);
       moddir = cwd;
     } else {
       moddir = dir;
@@ -270,7 +269,6 @@ class Package {
 
     // Handle sources.
     if (matched) {
-      const protocol = matched[1];
       let url = null;
 
       if (matched[2])
@@ -278,7 +276,7 @@ class Package {
       else
         url = matched[1] + matched[3];
 
-      let [host, extra] = url.split('#');
+      const [host, extra] = url.split('#');
       const {branch, version} = findVersion(extra);
 
       git = host;
@@ -315,7 +313,7 @@ class Package {
         if (!this.env.basedir)
           throw new Error('Unknown base.');
 
-        dir = path.resolve(this.env.basedir, dir)
+        dir = path.resolve(this.env.basedir, dir);
       }
 
       git = `file://${dir}/${repo}/.git`;
@@ -462,7 +460,7 @@ class Package {
       if (version) {
         const match = matchTag(keys, version);
         if (!match)
-          throw new Error(`Unknown tag for '${name}'.`);
+          throw new Error(`Unknown tag for '${git}'.`);
 
         tag = tags[match];
       } else {
@@ -609,7 +607,7 @@ class Package {
     });
 
     if (!dst)
-      return;
+      return null;
 
     if (!branch) {
       if (!git)
@@ -730,7 +728,7 @@ class Package {
         });
 
         if (!dst)
-          return;
+          return 1;
 
         const pkg = await Package.fromDirectory({
           dir: dst,
@@ -855,7 +853,7 @@ class Package {
     }
 
     if (!data)
-      throw new Error(`Unknown package at ${dst}.`);
+      throw new Error(`Unknown package at ${filename}.`);
 
     return JSON.parse(data);
   }
@@ -872,7 +870,7 @@ class Package {
   }
 
   static sortDependencyEntries(a, b) {
-    if (a[0] == b[0])
+    if (a[0] === b[0])
       return 0;
     else
       return a[0] < b[0] ? -1 : 1;
@@ -1053,7 +1051,7 @@ class Package {
       }
 
       return false;
-    }
+    };
 
     return checkPackage(this.dir);
   }
@@ -1169,7 +1167,7 @@ class Package {
 
   async getKeepPatterns(src) {
     if (!Array.isArray(this.info.files))
-      throw new Error(`Package 'files' is not an array.`);
+      throw new Error('Package \'files\' is not an array.');
 
     const patterns = [];
 
@@ -1231,7 +1229,7 @@ class Package {
       bundleDependencies = this.info.bundleDependencies;
 
     if (!Array.isArray(bundleDependencies))
-      throw new Error(`Package 'bundledDependencies' not an array.`);
+      throw new Error('Package \'bundledDependencies\' not an array.');
 
     file = file.replace(base, '');
 
@@ -1242,7 +1240,7 @@ class Package {
       if (bundleDependencies.includes(name))
         return [true, true];
       else
-        return [true, false]
+        return [true, false];
     }
 
     return [false, false];
@@ -1326,7 +1324,7 @@ class Package {
 
       for (const file of files) {
         if (inverse)
-          keep.add(file)
+          keep.add(file);
         else
           ignore.add(file);
       }
@@ -1346,13 +1344,13 @@ class Package {
 
         for (const file of files) {
           if (inverse)
-            keep.add(file)
+            keep.add(file);
           else
             ignore.add(file);
         }
       }
 
-      let dirents = await readdir(from, {withFileTypes: true});
+      const dirents = await readdir(from, {withFileTypes: true});
 
       await mkdir(to);
 
@@ -1373,7 +1371,7 @@ class Package {
           await copyFile(fromPath, toPath);
         }
       }
-    }
+    };
 
     await copyDirectory(src, dst);
   }
@@ -1408,7 +1406,7 @@ class Package {
     if (!data)
       throw new Error(`Unknown package at ${dst}.`);
 
-    const info = JSON.parse(data)
+    const info = JSON.parse(data);
 
     info._from = src;
     info._resolved = `git+${url}#${commit}`;
@@ -1432,7 +1430,7 @@ class Package {
 
     try {
       await access(gyp, fs.constants.R_OK);
-      has = true
+      has = true;
     } catch (err) {
       if (err.code !== 'ENOENT')
         throw err;
@@ -1449,7 +1447,7 @@ class Package {
 
   async rebuildModule(dir) {
     if (!await this.hasAddon(dir))
-      return;
+      return null;
 
     return new Promise((resolve, reject) => {
       const child = spawn('node', [nodeGyp, 'rebuild'], {
@@ -1460,8 +1458,6 @@ class Package {
       child.once('exit', code => resolve(code));
       child.once('error', err => reject(err));
     });
-
-    return 0;
   }
 
   /**
@@ -1613,13 +1609,7 @@ class Package {
       location = this.env.globalBinDir;
 
     if (location && this.info.bin) {
-      for (const [name, rel] of Object.entries(this.info.bin)) {
-        let libdir = this.dir;
-
-        if (options.global)
-          libdir = path.join(this.env.globalLibDir, this.info.name);
-
-        const target = path.relative(location, path.join(libdir, rel));
+      for (const [name] of Object.entries(this.info.bin)) {
         const bin = path.join(location, name);
 
         this.env.log(`Unlinking '${this.info.name}' at '${bin}'.`);
@@ -1692,7 +1682,7 @@ class Package {
 
     this.env.log(`Running '${name}' at '${this.dir}' for ` +
                  `'${this.info.name}@${this.info.version}'.`);
-    this.env.log(`Command '${this.info.scripts[name]}'.`)
+    this.env.log(`Command '${this.info.scripts[name]}'.`);
 
     let [cmd, ...args] = this.info.scripts[name].split(' ');
 

--- a/test/common.js
+++ b/test/common.js
@@ -21,8 +21,8 @@ const {tmpdir} = require('os');
 const {randomBytes} = require('crypto');
 const path = require('path');
 const util = require('util');
-const child_process = require('child_process');
-const exec = util.promisify(child_process.exec);
+const cp = require('child_process');
+const exec = util.promisify(cp.exec);
 const fs = require('fs');
 const rmdir = util.promisify(fs.rmdir);
 const readdir = util.promisify(fs.readdir);
@@ -52,8 +52,8 @@ function testfile(name) {
 }
 
 async function unpack(tar, dst) {
-  const cmd = `tar xf ${tar} -C ${dst}`
-  const {stdout, stderr} = await exec(cmd);
+  const cmd = `tar xf ${tar} -C ${dst}`;
+  await exec(cmd);
 }
 
 async function rimraf(p) {
@@ -89,4 +89,4 @@ module.exports = {
   unpack,
   envar,
   rimraf
-}
+};

--- a/test/git-test.js
+++ b/test/git-test.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-env mocha */
+
 'use strict';
 
 const assert = require('assert');
@@ -27,15 +29,13 @@ const {
   matchTag,
   cloneRepo,
   verifyRepo,
-  listTree,
-  checksum,
   treeHash,
   cloneFiles
 } = require('../lib/git');
 
-const {datadir, testdir, clean, testfile, unpack} = require('./common');
+const {datadir, testdir, clean, unpack} = require('./common');
 
-describe('Git', function() {
+describe('Git', () => {
   const repo = path.join(datadir, 'repo.tar.gz');
   const tcleanup = [];
   const tdir = testdir('repo', tcleanup);
@@ -54,7 +54,7 @@ describe('Git', function() {
     await clean(cleanup);
   });
 
-  describe('listTags()', function() {
+  describe('listTags()', () => {
     it('should find all tags', async () => {
       const git = path.join(tdir, 'repo', '.git');
 
@@ -83,7 +83,7 @@ describe('Git', function() {
     });
   });
 
-  describe('matchTag()', function() {
+  describe('matchTag()', () => {
     it('should find matching semver tags', async () => {
       const tags = ['v1.0.0', 'v1.1.0', 'v2.0.0'];
 
@@ -100,7 +100,7 @@ describe('Git', function() {
     });
   });
 
-  describe('cloneRepo()/verifyRepo()', function() {
+  describe('cloneRepo()/verifyRepo()', () => {
     it('should clone and verify signature', async () => {
       let err = null;
       const git = path.join(tdir, 'repo', '.git');
@@ -153,7 +153,7 @@ describe('Git', function() {
     });
   });
 
-  describe('treeHash()', function() {
+  describe('treeHash()', () => {
     it('should compute a sha512 tree of git tree', async () => {
       const git = path.join(tdir, 'repo', '.git');
       const base = path.join(tdir, 'repo');
@@ -178,7 +178,7 @@ describe('Git', function() {
     });
   });
 
-  describe('cloneFiles()', function() {
+  describe('cloneFiles()', () => {
     it('should clone files to destination', async () => {
       let err = null;
       const git = path.join(tdir, 'repo', '.git');

--- a/test/package-test.js
+++ b/test/package-test.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+/* eslint-env mocha */
+
 'use strict';
 
 const assert = require('assert');
@@ -32,7 +34,7 @@ describe('Package', function() {
   this.timeout(60000);
 
   const stdoutPath = `${testfile('stdout')}`;
-  const stderrPath = `${testfile('stderr')}`
+  const stderrPath = `${testfile('stderr')}`;
   const tcleanup = [stdoutPath, stderrPath];
   const gdir = testdir('global', tcleanup);
   const tdir = testdir('modules', tcleanup);
@@ -76,7 +78,7 @@ describe('Package', function() {
     await clean(cleanup);
   });
 
-  describe('resolveRemote()', function() {
+  describe('resolveRemote()', () => {
     const hash = '3c0cfdd8445ec81386daa187feb2d32b9f4d89a1';
 
     const remotes = {
@@ -91,40 +93,40 @@ describe('Package', function() {
       {
         input: {
           name: 'bdb',
-          src: 'github:bcoin-org/bdb#semver:~1.1.7',
+          src: 'github:bcoin-org/bdb#semver:~1.1.7'
         },
         output: {
           git: 'https://github.com/bcoin-org/bdb.git',
           version: '~1.1.7',
-          branch: null,
+          branch: null
         }
       },
       {
         input: {
           name: 'bdb',
-          src: 'github:bcoin-org/bdb#v1.1.7',
+          src: 'github:bcoin-org/bdb#v1.1.7'
         },
         output: {
           git: 'https://github.com/bcoin-org/bdb.git',
           version: null,
-          branch: 'v1.1.7',
+          branch: 'v1.1.7'
         }
       },
       {
         input: {
           name: 'bdb',
-          src: `github:bcoin-org/bdb#${hash}`,
+          src: `github:bcoin-org/bdb#${hash}`
         },
         output: {
           git: 'https://github.com/bcoin-org/bdb.git',
           version: null,
-          branch: `${hash}`,
+          branch: `${hash}`
         }
       },
       {
         input: {
           name: 'bdb',
-          src: 'gitlab:bcoin-org/bdb#semver:~1.1.7',
+          src: 'gitlab:bcoin-org/bdb#semver:~1.1.7'
         },
         output: {
           git: 'https://gitlab.com/bcoin-org/bdb.git',
@@ -265,10 +267,8 @@ describe('Package', function() {
     }
   });
 
-  describe('fromDirectory()', function() {
+  describe('fromDirectory()', () => {
     it('should locate and read package.json', async () => {
-      let err = null;
-
       const moddir = path.join(tdir, 'modules', 'foo', 'lib');
       const mod = await Package.fromDirectory({
         dir: moddir,
@@ -283,7 +283,7 @@ describe('Package', function() {
         version: '1.0.0',
         main: './lib/index.js',
         remotes: {
-          local: 'git+file://',
+          local: 'git+file://'
         },
         dependencies: {
           bar: 'local:bar#semver:^1.0.0',
@@ -294,7 +294,7 @@ describe('Package', function() {
     });
   });
 
-  describe('install()', function() {
+  describe('install()', () => {
     async function exists(dst) {
       let stats = null;
       try {
@@ -302,7 +302,6 @@ describe('Package', function() {
       } catch (err) {
         if (err.code !== 'ENOENT')
           throw err;
-
       }
       return stats ? true : false;
     }
@@ -348,7 +347,7 @@ describe('Package', function() {
       const f3 = path.join(base, 'f');
 
       assert.equal(await exists(f1), false);
-      assert.equal(await exists(f1), false);
+      assert.equal(await exists(f2), false);
       assert.equal(await exists(f3), true);
     });
 


### PR DESCRIPTION
I ran gpk against the usual bcoin eslint rules and fixed a bunch of stuff like missing semicolons, etc.

Several variables are defined but never used, I'm not sure if those are left in place for future extensions, but took them out in this PR to be completely clean.

There were also several undefined variables being used. By context I was able to fix most of those with one exception:

`file` is undefined in line 1323: ` keep.has(this.env.normalizePath(file)))` I'm not sure if it that is supposed to be part of the following foreach loop or the previous one.

https://github.com/braydonf/gpk/blob/7b6dfecc6cf6ac8823b3214e98e91a6dcdd2ab35/lib/package.js#L1310-L1333


All tests still pass but I'm guessing the actual bug are in untested error paths, so I need to dig deeper to ensure the fixes are correct.

We can break this PR up into chunks or by "class" of fix if you want to even pursue it.